### PR TITLE
fix: switch to use new IPNetwork2 namespace

### DIFF
--- a/IPNetwork.csproj
+++ b/IPNetwork.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IPNetwork2" Version="2.6.556" />
+    <PackageReference Include="IPNetwork2" Version="3.0.667" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/IPNetwork.psm1
+++ b/IPNetwork.psm1
@@ -16,5 +16,5 @@ filter Get-IPNetwork {
     [Parameter(Mandatory, ValueFromPipeline)]
     [string]$Address
   )
-  [IPNetwork]::Parse($Address)
+  [IPNetwork2]::Parse($Address)
 }


### PR DESCRIPTION
Closes https://github.com/JustinGrote/IPNetwork/issues/1
Bump `csproj` version.
Update function to use `[IPNetwork2]` class.